### PR TITLE
Monkeypatch `time` to get support of legacy `Crypto.Random` and `paramiko`

### DIFF
--- a/bin/ssh-keygen.py
+++ b/bin/ssh-keygen.py
@@ -16,6 +16,12 @@ import sys
 import argparse
 import paramiko
 
+# monkeypatch for paramiko and Crypto.Random
+# global mlpatches.time_patches.CLOCK_PATCH can be disabled
+import time
+time.clock = time.perf_counter
+
+
 SSH_DIRS = [
     os.path.expanduser("~/.ssh"),
     os.path.join(os.environ["STASH_ROOT"], ".ssh"),

--- a/bin/ssh.py
+++ b/bin/ssh.py
@@ -46,6 +46,12 @@ if (paramiko is None) or (Version(paramiko.__version__) < Version("1.15")):
     _stash("pip install paramiko==1.16.0")
     print("Please restart Pythonista for changes to take full effect")
     sys.exit(0)
+    
+    
+# monkeypatch for paramiko and Crypto.Random
+# global mlpatches.time_patches.CLOCK_PATCH can be disabled
+import time
+time.clock = time.perf_counter
 
 
 class StashSSH(object):

--- a/lib/mlpatches/base.py
+++ b/lib/mlpatches/base.py
@@ -28,6 +28,11 @@ class IncompatiblePatch(Exception):
     """raised when a patch is incompatible."""
 
     pass
+    
+    
+class AttributeUndefined:
+    """Special Type to mark if patched attribute was not defined and should be deletted"""
+    pass
 
 
 class BasePatch(object):
@@ -123,13 +128,20 @@ class FunctionPatch(BasePatch):
             # If the module is already loaded, get it from sys.modules
             module = sys.modules[self.module]
 
-        self.old = getattr(module, self.function)
+        try:
+            self.old = getattr(module, self.function)
+        except AttributeError:
+            # handle undefined attribute
+            self.old = AttributeUndefined
         setattr(module, self.function, self.replacement)
 
     def do_disable(self):
         module = sys.modules[self.module]
         if self.old is not None:
             setattr(module, self.function, self.old)
+        # delete undefined attribute
+        if self.old is AttributeUndefined:
+            delattr(module, self.function)
 
 
 class ModulePatch(BasePatch):

--- a/lib/mlpatches/patches.py
+++ b/lib/mlpatches/patches.py
@@ -5,21 +5,22 @@ from stash.system.shcommon import _STASH_EXTENSION_PATCH_PATH
 
 from stashutils.core import load_from_dir
 
-from mlpatches import base, os_patches, modulepatches
+from mlpatches import base, os_patches, modulepatches, time_patches
 from mlpatches import mount_patches
 
 STABLE_PATCHES = {  # name -> Patch()
-    "os_popen": os_patches.POPEN_PATCH,
-    "os_popen2": os_patches.POPEN2_PATCH,
-    "os_popen3": os_patches.POPEN3_PATCH,
-    "os_popen4": os_patches.POPEN4_PATCH,
-    "os_system": os_patches.SYSTEM_PATCH,
+    # "os_popen": os_patches.POPEN_PATCH,
+    # "os_popen2": os_patches.POPEN2_PATCH,
+    # "os_popen3": os_patches.POPEN3_PATCH,
+    # "os_popen4": os_patches.POPEN4_PATCH,
+    # "os_system": os_patches.SYSTEM_PATCH,
     "os_getpid": os_patches.GETPID_PATCH,
     "os_getppid": os_patches.GETPPID_PATCH,
     "os_kill": os_patches.KILL_PATCH,
     "OS_POPEN": os_patches.POPEN_PATCHES,
     "OS_PROCESSING": os_patches.PROCESSING_PATCHES,
     "OS": os_patches.OS_PATCHES,
+    "time_clock": time_patches.CLOCK_PATCH,
 }
 
 INSTABLE_PATCHES = {  # name -> Patch()

--- a/lib/mlpatches/time_patches.py
+++ b/lib/mlpatches/time_patches.py
@@ -1,0 +1,13 @@
+from mlpatches import base
+import time
+
+class ClockPatch(base.FunctionPatch):
+    """patch for os.listdir()"""
+    
+    PY3 = True
+    module = "time"
+    function = "clock"
+    replacement = time.perf_counter
+    
+
+CLOCK_PATCH = ClockPatch()


### PR DESCRIPTION
* Patched `time.clock()` (required by Crypto)
* Allow patch undefined attributes
* Apply patch to `bin/ssh.py`
* Apply patch to `bin/ssh-keygen.py`